### PR TITLE
Fixing Android Text Entry Alignment by modifying Custom Entry Rendere…

### DIFF
--- a/VidyoConnector.Android/Renderers/CustomEntryRenderer.cs
+++ b/VidyoConnector.Android/Renderers/CustomEntryRenderer.cs
@@ -12,6 +12,10 @@ namespace VidyoConnector.Android
             // Hides the underlined text in the Xamarin.Forms.Entry UI item
             base.OnElementChanged(e);
             Control?.SetBackgroundColor(Color.Transparent);
+            if (Control != null)
+            {
+                Control.SetPadding(10, 30, 10, 0);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixing android text entry by modifying Custom Entry Renderer (renderer incorrectly cuts off text if padding is not set correctly on change) 